### PR TITLE
Better spacing, handling case where different rows have different keys defined

### DIFF
--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -2,101 +2,102 @@ var program = require('commander');
 var AWS = require('aws-sdk');
 AWS.config.loadFromPath('./config.json');
 var dynamoDB = new AWS.DynamoDB();
-
-var iKnowTheHeaders = false;
+var headers = [];
 
 program.version('0.0.1').option('-t, --table [tablename]', 'Add the table you want to output to csv').option("-d, --describe").parse(process.argv);
 
-if(!program.table) {
-	console.log("You must specify a table");
-	program.outputHelp();
-	process.exit(1);
+if (!program.table) {
+    console.log("You must specify a table");
+    program.outputHelp();
+    process.exit(1);
 }
 
 var query = {
-	"TableName": program.table,
-	"Limit": 1000,
+    "TableName": program.table,
+    "Limit": 1000,
 };
 
 
 var describeTable = function(query) {
 
-    dynamoDB.describeTable({"TableName": program.table}, function(err, data) {
+    dynamoDB.describeTable({
+        "TableName": program.table
+    }, function(err, data) {
 
-			if(!err) {
+        if (!err) {
 
-				console.dir(data.Table);
+            console.dir(data.Table);
 
-			} else console.dir(err);
-		});
-	}
+        } else console.dir(err);
+    });
+}
 
 
 var scanDynamoDB = function(query) {
 
-		dynamoDB.scan(query, function(err, data) {
+    dynamoDB.scan(query, function(err, data) {
 
-			if(!err) {
+        if (!err) {
 
-				printout(data.Items) // Print out the subset of results.
-				if(data.LastEvaluatedKey) { // Result is incomplete; there is more to come.
-					query.ExclusiveStartKey = data.LastEvaluatedKey;
-					scanDynamoDB(query);
-				};
-			} else console.dir(err);
+            printout(data.Items) // Print out the subset of results.
+            if (data.LastEvaluatedKey) { // Result is incomplete; there is more to come.
+                query.ExclusiveStartKey = data.LastEvaluatedKey;
+                scanDynamoDB(query);
+            };
+        } else console.dir(err);
 
-		});
-	};
+    });
+};
 
 function arrayToCSV(array_input) {
-	var string_output = "";
-	for(var i = 0; i < array_input.length; i++) {
-		string_output += ('"' + array_input[i].replace('"', '\"') + '"')
-		if(i != array_input.length - 1) string_output += ","
-	};
-	return string_output;
+    var string_output = "";
+    for (var i = 0; i < array_input.length; i++) {
+        string_output += ('"' + array_input[i].replace('"', '\"') + '"')
+        if (i != array_input.length - 1) string_output += ","
+    };
+    return string_output;
 }
 
 function printout(items) {
+    var headersMap = {};
+    var values;
+    var header;
+    var value;
 
-	if(!iKnowTheHeaders) {
-		var headers = [];
-		if(items.length > 0) {
-			for(var propertyName in items[0]) headers.push(propertyName)
-			console.log(arrayToCSV(headers))
-			iKnowTheHeaders = true;
-		}
-	}
-
-	for(index in items)
-
-	{
-
-		var values = []
-		for(var propertyName in items[index])
-
-		{
-            if (items[index][propertyName].N) {
-                var value = items[index][propertyName].N;
+    if (headers.length == 0) {
+        if (items.length > 0) {
+            for (var i = 0; i < items.length; i++) {
+                for (var key in items[i]) {
+                    headersMap[key] = true;
+                }
             }
-            else if (items[index][propertyName].S) {
-                var value = items[index][propertyName].S;
+        }
+        for (var key in headersMap) {
+            headers.push(key);
+        }
+        console.log(arrayToCSV(headers))
+    }
+
+    for (index in items) {
+        values = [];
+        for (i = 0; i < headers.length; i++) {
+            value = "";
+            header = headers[i];
+            // Loop through the header rows, adding values if they exist
+            if (items[index].hasOwnProperty(header)) {
+                if (items[index][header].N) {
+                    value = items[index][header].N;
+                } else if (items[index][header].S) {
+                    value = items[index][header].S;
+                } else if (items[index][header].SS) {
+                    value = items[index][header].SS.toString();
+                }
             }
-            else if (items[index][propertyName].SS) {
-                var value = items[index][propertyName].SS.toString();
-            }
-            else {
-                var value = "";
-            }
-
-			values.push(value)
-		}
-		console.log(arrayToCSV(values))
-
-
-
-	}
-
+            values.push(value)
+        }
+        console.log(arrayToCSV(values))
+    }
 }
-if(program.describe) describeTable(query);
+
+if (program.describe) describeTable(query);
 else scanDynamoDB(query);


### PR DESCRIPTION
Hello edasque,

Thanks for your tool. It didn't work for me when I had DynamoDB data where different rows had different header values defined (it was only using the header values from the first row).

I have fixed it (and the spacing) with this commit.

Thanks.