### PR TITLE
properly escape all quote occurrences

### DIFF
--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -52,7 +52,7 @@ var scanDynamoDB = function(query) {
 function arrayToCSV(array_input) {
     var string_output = "";
     for (var i = 0; i < array_input.length; i++) {
-        string_output += ('"' + array_input[i].replace('"', '\"') + '"')
+        string_output += ('"' + array_input[i].replace(/\"/g, '\\"') + '"')
         if (i != array_input.length - 1) string_output += ","
     };
     return string_output;


### PR DESCRIPTION
With the current implementation the quotes are not replaced properly. Plus, replace would actually only replace the first quote occurrence.

I have tested this change locally with a dataset containing json blobs in some data fields but happy to discuss better implementations!