### PR TITLE
add dynamo maps to the export

### DIFF
--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -94,6 +94,8 @@ function printout(items) {
                     value = items[index][header].SS.toString();
                 } else if (items[index][header].B) {
                     value = items[index][header].B.toString('base64');
+                } else if (items[index][header].M) {
+                    value = JSON.stringify(items[index][header].M);
                 }
             }
             values.push(value)


### PR DESCRIPTION
Not sure if it this is a relatively new feature but at least from the Java SDK HashMaps are stored this way. 

I have used JSON.stringify so that we can get a proper representation of the map even if there are nested objects