### PR TITLE
Support for Java Lists

### DIFF
--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -96,6 +96,8 @@ function printout(items) {
                     value = items[index][header].B.toString('base64');
                 } else if (items[index][header].M) {
                     value = JSON.stringify(items[index][header].M);
+                } else if (items[index][header].L) {
+                    value = JSON.stringify(items[index][header].L);
                 }
             }
             values.push(value)


### PR DESCRIPTION
Same as HashMaps, when you use Lists with the AWS Java SDK they are stored with a "L".

Again, JSON.stringify as they are stored internally with something similar to this:

"dynamoDBField": {
    "L": [
      {
        "S": "5f4a9c3d-adb6-4f51-a0ec-8ea7f5f67306"
      },
      {
        "S": "5f4a9c3d-adb6-4f51-a0ec-8ea7f5f67306"
      },
      {
        "S": "cc0f77e9-3830-4b34-b344-c8400d5c42d8"
      },
      {
        "S": "392c9733-de3f-4ea2-8ae4-e4f3dbce74f8"
      },
      {
        "S": "cc0f77e9-3830-4b34-b344-c8400d5c42d8"
      },
      {
        "S": "2f84bc97-2002-40bd-a509-e064fee3f44f"
      }
    ]
  }