### PR TITLE
boolean fields support

### DIFF
--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -98,6 +98,8 @@ function printout(items) {
                     value = JSON.stringify(items[index][header].M);
                 } else if (items[index][header].L) {
                     value = JSON.stringify(items[index][header].L);
+                } else if (items[index][header].BOOL) {
+                    value = items[index][header].BOOL.toString();
                 }
             }
             values.push(value)


### PR DESCRIPTION
This is arguably a bit quirky but I am not sure about how to better support it.

Dynamo stores boolean fields under the "BOOL" key and to make things better elements are only returned when the boolean field is set to true and the actual value is not in a string format (this is why the toString call). Not sure about what would be the proper representation of a boolean field in a CSV file either.

Happy to further discuss better ways of exporting these fields!