### PR TITLE
Handle boolean values properly

### DIFF
--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -100,7 +100,7 @@ function printout(items) {
                     value = JSON.stringify(items[index][header].M);
                 } else if (items[index][header].L) {
                     value = JSON.stringify(items[index][header].L);
-                } else if (items[index][header].BOOL) {
+                } else if (items[index][header].BOOL !== undefined) {
                     value = items[index][header].BOOL.toString();
                 }
             }


### PR DESCRIPTION
Fix the problem where if a boolean "false" value is encountered, it will be dumped as an empty string instead of the string "false" (this happens because `items[index][header].BOOL` will return evaluate to false if the value of the boolean is false.