### PR TITLE
Adding support for automatically-loaded credentials

### DIFF
--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -1,18 +1,21 @@
 var program = require('commander');
 var AWS = require('aws-sdk');
-if (!AWS.config.credentials) {
-    AWS.config.loadFromPath('./config.json');
-}
-var dynamoDB = new AWS.DynamoDB();
 var headers = [];
 
-program.version('0.0.1').option('-t, --table [tablename]', 'Add the table you want to output to csv').option("-d, --describe").parse(process.argv);
+program.version('0.0.1').option('-t, --table [tablename]', 'Add the table you want to output to csv').option("-d, --describe").option("-r, --region [regionname]").parse(process.argv);
 
 if (!program.table) {
     console.log("You must specify a table");
     program.outputHelp();
     process.exit(1);
 }
+
+if (program.region && AWS.config.credentials) {
+    AWS.config.update({region: program.region});
+} else {
+    AWS.config.loadFromPath('./config.json');
+}
+var dynamoDB = new AWS.DynamoDB();
 
 var query = {
     "TableName": program.table,

--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -1,6 +1,8 @@
 var program = require('commander');
 var AWS = require('aws-sdk');
-AWS.config.loadFromPath('./config.json');
+if (!AWS.config.credentials) {
+    AWS.config.loadFromPath('./config.json');
+}
 var dynamoDB = new AWS.DynamoDB();
 var headers = [];
 


### PR DESCRIPTION
The AWS JS SDK supports a couple methods of automatically specifying service credentials, such as the AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY environment variables and the ~/.aws/credentials shared credentials file. This PR adds support for those by only loading from config.json if AWS.config.credentials isn't already set, and adds a --region command line argument for specifying the region without a configuration file.