### PR TITLE
Use the explicitly defined headers and data form of the unparse function

### DIFF
--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -52,19 +52,12 @@ var scanDynamoDB = function ( query ) {
         scanDynamoDB(query);
       }
       else {
-        let dummyRow = {};
-        headers.forEach( function ( key ) {
-          dummyRow[key] = 'dummy';
-        });
-
-        // console.log( JSON.stringify( dummyRow ) );
-        unMarshalledArray.unshift( dummyRow );
-        console.log(Papa.unparse( unMarshalledArray ));
+        console.log(Papa.unparse( { fields: [ ...headers ], data: unMarshalledArray } ));
       }
-    } 
-    else 
+    }
+    else {
       console.dir(err);
-
+    }
   });
 };
 


### PR DESCRIPTION
in order to render the “dummy” row unnecessary. Otherwise, Papaparse
will look at the keys in the first row object of the input array, to determine
the headers that will exist in the CSV output