### PR TITLE
Revert "Fixes the issue where large data sets cause a heap error."

### DIFF
--- a/dynamoDBtoCSV.js
+++ b/dynamoDBtoCSV.js
@@ -5,7 +5,6 @@ var unmarshal = require('dynamodb-marshaler').unmarshal;
 var Papa = require('papaparse');
 var headers = [];
 var unMarshalledArray = [];
-var firstRun = true;
 
 program
   .version('0.0.1')
@@ -71,6 +70,9 @@ var scanDynamoDB = function ( query ) {
         query.ExclusiveStartKey = data.LastEvaluatedKey;
         scanDynamoDB(query);
       }
+      else {
+        console.log(Papa.unparse( { fields: [ ...headers ], data: unMarshalledArray } ));
+      }
     }
     else {
       console.dir(err);
@@ -105,19 +107,6 @@ function unMarshalIntoArray( items ) {
     unMarshalledArray.push( newRow );
 
   });
-
-  if (firstRun) {
-    headers.forEach( function (key, index) {
-      if (!unMarshalledArray[0].hasOwnProperty(key)) {
-        unMarshalledArray[0][key] = null;
-      }
-    });
-    console.log(Papa.unparse(unMarshalledArray));
-    firstRun = false;
-  } else {
-    console.log(Papa.unparse(unMarshalledArray, {header: false}));
-  }
-  unMarshalledArray = [];
 
 }
 


### PR DESCRIPTION
This reverts commit 3afcb35b554f8f8abe75d77ffde5e8d70d95790b.

That commit introduced a bug when order of columns differ between
subsequent console prints and this results in completely invalid
CSV files having values mixed up. Moreover, the commit does
an assumption that all attributes are returned in 1000 first
items which might not be always true. Heap error needs to be fixed
by possibly dumping interim results to a file or in some other way,
e.g. producing multiple partial CSV files, which then could be merged
using other tool, but logic anyway should be free of any tricky assumptions.